### PR TITLE
Update cool.cson

### DIFF
--- a/grammars/cool.cson
+++ b/grammars/cool.cson
@@ -1,7 +1,8 @@
 'name': 'Cool'
 'scopeName': 'source.cool'
 'fileTypes': [
-	'cl'
+	'cl',
+	'cool'
 ]
 
 'repository': {


### PR DESCRIPTION
I have seen `.cool` file extension more often than `.cl`, so I thought this plugin should handle both file extensions.